### PR TITLE
Upgrading Automaton to Elm 0.18.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.0",
+    "version": "2.0.0",
     "summary": "experimental library for structuring code, based on Arrowized FRP",
     "repository": "https://github.com/evancz/automaton.git",
     "license": "BSD3",
@@ -10,7 +10,7 @@
         "Automaton"
     ],
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.17.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
1. Used elm-format and elm-upgrade on the code to bring it up to 0.18.
2. Removed "run" which depends on Signal, which was obsoleted in v0.17.